### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/test1/bcc89eac-c6c3-4075-b546-759abc5bd48d/f0764acd-a4dc-451a-b0de-f7b5825dcae5/_apis/work/boardbadge/2cdf9ad4-5828-4678-9dfb-d2c017c3f3eb)](https://codedev.ms/test1/bcc89eac-c6c3-4075-b546-759abc5bd48d/_boards/board/t/f0764acd-a4dc-451a-b0de-f7b5825dcae5/Microsoft.RequirementCategory)
 # TestA


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/test1/bcc89eac-c6c3-4075-b546-759abc5bd48d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.