### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/OrgFromGH/4d518b36-fb18-42a3-a3f8-a84a73c3446b/06d7e183-d8b7-4f9e-a10e-a1214051bb60/_apis/work/boardbadge/0f9b9915-8100-4c4c-acd0-5dfa72528475)](https://codedev.ms/OrgFromGH/4d518b36-fb18-42a3-a3f8-a84a73c3446b/_boards/board/t/06d7e183-d8b7-4f9e-a10e-a1214051bb60/Microsoft.RequirementCategory)
 # TestA


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/OrgFromGH/4d518b36-fb18-42a3-a3f8-a84a73c3446b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.