### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://codedev.ms/A/0a4b7d81-7c74-4c60-8b7a-111bb52b5f60/cff80394-dcfe-48da-a29f-1464dca22739/_apis/work/boardbadge/8d8b2d89-6f98-4dbe-81e1-a0ff5f57dad8)](https://codedev.ms/A/0a4b7d81-7c74-4c60-8b7a-111bb52b5f60/_boards/board/t/cff80394-dcfe-48da-a29f-1464dca22739/Microsoft.RequirementCategory)
 # TestA


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/A/0a4b7d81-7c74-4c60-8b7a-111bb52b5f60/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.